### PR TITLE
Add comprehensive WelcomeCrew review artifacts

### DIFF
--- a/REVIEW/ARCH_MAP.md
+++ b/REVIEW/ARCH_MAP.md
@@ -1,0 +1,21 @@
+# Architecture & Flow Map
+
+## Current Flow (Monolith snapshot)
+1. **Gateway startup** — `bot_welcomecrew.py` bootstraps the Discord bot, syncs slash commands, and (attempts to) preload clan tags via `_load_clan_tags`.
+2. **Member activity** — Thread messages are handled in `on_message`; close markers trigger `_finalize_{welcome,promo}` to write to Google Sheets, while missing tags enqueue `_pending_*` entries and prompt recruiters.
+3. **Sheets access** — Helpers such as `get_ws`, `upsert_welcome`, and `_load_clan_tags` use gspread synchronously and are offloaded via `_run_blocking` in some call sites.
+4. **Backfill** — `!backfill_tickets` walks both channels, reuses the same parsing stack, and pushes writes through throttled upserts.
+5. **Ops surface** — Prefix commands expose maintenance tools (env check, dedupe, reboot) with no permission layer; `/help` points users to the command catalog.
+6. **Keepalive** — An aiohttp web server provides `/healthz`, while a scheduled refresh task (`scheduled_refresh_loop`) reloads clan tags three times per day.
+
+## Target Carve-out Interfaces to Stabilize
+- **Sheets Adapter Layer** — gspread client factory, worksheet cache, and upsert/dedupe helpers (candidate for extraction into `welcomecrew/sheets.py`).
+- **Clan Tag Cache** — Non-blocking loader with TTL + refresh (should expose async `ensure_clan_tags_loaded(force: bool=False)` and sync `match_tag(text)` APIs).
+- **Ticket Router** — Parsing (`parse_welcome_thread_name_allow_missing`, `parse_promo_thread_name`), pending-state tracking, and prompt UX.
+- **Command Surface** — Prefix + slash commands gated for admins, mirroring Reminder’s permission scaffolding; keep as thin wrappers over service layer functions.
+- **Observers** — `on_message`/`on_thread_update` watchers and stale-ticket sweep (future work) should remain isolated from Sheets concerns via dependency injection.
+
+## Immediate Refactors Post-Fix
+1. Extract a `permissions` module that defines recruiter/admin checks and reuse across commands/tests.
+2. Move `_pending_*` management + prompt orchestration behind a ticket service so it can be unit-tested without Discord objects.
+3. Wrap Sheets retries/backoff in a reusable utility (shared with Reminder) before moving into a dedicated package.

--- a/REVIEW/FINDINGS.md
+++ b/REVIEW/FINDINGS.md
@@ -1,0 +1,4 @@
+# Findings
+
+1. **F-01 — Prefix commands lack permission guards (High · Security).** See details in [REVIEW.md](./REVIEW.md#security--f-01-prefix-commands-lack-permission-guards).
+2. **F-02 — Clan tag cache reload blocks the gateway loop (High · Robustness).** See details in [REVIEW.md](./REVIEW.md#robustness--f-02-clan-tag-cache-reload-blocks-the-gateway-loop).

--- a/REVIEW/HOTSPOTS.csv
+++ b/REVIEW/HOTSPOTS.csv
@@ -1,0 +1,3 @@
+file,path,function,start_line,end_line,complexity,loc,tags,notes
+bot_welcomecrew.py,bot_welcomecrew.py,cmd_backfill,1132,1206,17,75,"async,io","Progress loop + dual channel scans; consider extracting per-channel workers for testability."
+bot_welcomecrew.py,bot_welcomecrew.py,on_message,1645,1724,22,80,"event-handler","High branching and shared mutable state; revisit after clan-tag loader fix to trim duplication."

--- a/REVIEW/LINT_REPORT.md
+++ b/REVIEW/LINT_REPORT.md
@@ -1,0 +1,3 @@
+# Lint Report
+
+- `ruff`/`flake8`: Not run (tooling not installed in review container). No blocking style issues identified manually beyond findings already captured.

--- a/REVIEW/PERF_NOTES.md
+++ b/REVIEW/PERF_NOTES.md
@@ -1,0 +1,5 @@
+# Performance Notes
+
+- Clan tag cache uses `get_all_values()`; acceptable with 8h TTL but should avoid blocking the gateway loop (see F-02 for fix).
+- Backfill throttles Sheets writes via `SHEETS_THROTTLE_MS`; keep under review when moving to multi-guild deployment.
+- Consider batching `ws.delete_rows` in `dedupe_sheet` if duplicates become frequent; current per-row deletes incur multiple API calls.

--- a/REVIEW/REVIEW.md
+++ b/REVIEW/REVIEW.md
@@ -1,0 +1,164 @@
+# WelcomeCrew Review
+
+## Executive Summary — **Red**
+The current WelcomeCrew extraction ships most of the reminder-derived surface area, but two high-severity gaps block a safe carve-out. Admin/maintenance commands (`!reboot`, `!backfill`, etc.) are exposed to any member with the prefix, and several hot paths still perform blocking Google Sheets fetches directly on the Discord gateway loop when clan tags are stale or a request fails. Either issue can take the bot offline (voluntarily or via timeouts) during onboarding rushes.
+
+## Findings by Severity & Category
+
+### High Severity
+
+#### Security — F-01: Prefix commands lack permission guards
+* **Location:** `bot_welcomecrew.py:1008-1287`
+* **Snippet:**
+  ```py
+  @bot.command(name="reboot")
+  @cmd_enabled(ENABLE_CMD_REBOOT)
+  async def cmd_reboot(ctx):
+      await ctx.reply("Rebooting…", mention_author=False)
+      await asyncio.sleep(1.0); os._exit(0)
+  ```
+* **Issue:** Every prefix command (including destructive ones such as `!reboot`, `!dedupe_sheet`, `!backfill_tickets`) is callable by any user who can speak where the bot is present. Reminder’s admin role gate is missing, so a newcomer can kill the process or spam Sheets writes.
+* **Fix (diff-ready):**
+  ```diff
+  diff --git a/bot_welcomecrew.py b/bot_welcomecrew.py
+  --- a/bot_welcomecrew.py
+  +++ b/bot_welcomecrew.py
+  @@
+  -from discord.ext import commands
+  +from discord.ext import commands
+  +from functools import wraps
+  @@
+  -def cmd_enabled(flag: bool):
+  -    def deco(func):
+  -        async def wrapper(ctx: commands.Context, *a, **k):
+  -            if not flag:
+  -                return await ctx.reply("This command is disabled by env flag.", mention_author=False)
+  -            return await func(ctx, *a, **k)
+  -        return wrapper
+  -    return deco
+  +ADMIN_PERMS = commands.has_guild_permissions(manage_guild=True)
+  +
+  +def cmd_enabled(flag: bool):
+  +    def deco(func):
+  +        @wraps(func)
+  +        async def wrapper(ctx: commands.Context, *a, **k):
+  +            if not flag:
+  +                return await ctx.reply("This command is disabled by env flag.", mention_author=False)
+  +            return await func(ctx, *a, **k)
+  +        return wrapper
+  +    return deco
+  @@
+  -@bot.command(name="env_check")
+  +@bot.command(name="env_check")
+  +@ADMIN_PERMS
+   async def cmd_env_check(ctx):
+       ...
+  @@
+  -@bot.command(name="backfill_tickets")
+  -@cmd_enabled(ENABLE_CMD_BACKFILL)
+  +@bot.command(name="backfill_tickets")
+  +@ADMIN_PERMS
+  +@cmd_enabled(ENABLE_CMD_BACKFILL)
+   async def cmd_backfill(ctx):
+       ...
+  @@
+  -@bot.command(name="reboot")
+  -@cmd_enabled(ENABLE_CMD_REBOOT)
+  +@bot.command(name="reboot")
+  +@ADMIN_PERMS
+  +@cmd_enabled(ENABLE_CMD_REBOOT)
+   async def cmd_reboot(ctx):
+       ...
+  ```
+* **Verify:**
+  - Confirm `!reboot`/`!backfill_tickets` fail for users without `Manage Server`.
+  - Confirm commands still work for admins and respect env toggles.
+  - Regression-test `!help` & watcher flows (no permission regressions).
+
+#### Robustness — F-02: Clan tag cache reload blocks the gateway loop
+* **Location:** `bot_welcomecrew.py:246-655`, `1667-1716`
+* **Snippet:**
+  ```py
+  def _match_tag_in_text(text: str) -> Optional[str]:
+      if not text: return None
+      _load_clan_tags(False)
+      if not _tag_regex_cache: return None
+      ...
+  ```
+* **Issue:** `_load_clan_tags` performs a blocking `worksheet.get_all_values()` call. When the cache is empty (first run, TTL expiry, or repeated API errors), every thread message, parse helper, and backfill path calls `_load_clan_tags` directly on the event loop. During Sheets outages this hard-blocks message handling, so close events are missed and the bot appears dead.
+* **Fix (diff-ready):**
+  ```diff
+  diff --git a/bot_welcomecrew.py b/bot_welcomecrew.py
+  --- a/bot_welcomecrew.py
+  +++ b/bot_welcomecrew.py
+  @@
+  -def _load_clan_tags(force: bool=False) -> List[str]:
+  +def _load_clan_tags(force: bool=False) -> List[str]:
+       global _clan_tags_cache, _clan_tags_norm_set, _last_clan_fetch, _tag_regex_cache
+       now = time.time()
+       if not force and _clan_tags_cache and (now - _last_clan_fetch < CLAN_TAGS_CACHE_TTL_SEC):
+           return _clan_tags_cache
+  @@
+       except Exception as e:
+           print("Failed to load clanlist:", e, flush=True)
+  -        _clan_tags_cache = []; _clan_tags_norm_set = set(); _tag_regex_cache = None
+  +        _last_clan_fetch = now
+  +        _clan_tags_cache = []; _clan_tags_norm_set = set(); _tag_regex_cache = None
+       return _clan_tags_cache
+  +
+  +def _clan_tags_need_refresh() -> bool:
+  +    if not _clan_tags_cache:
+  +        return True
+  +    return (time.time() - _last_clan_fetch) >= CLAN_TAGS_CACHE_TTL_SEC
+  +
+  +async def ensure_clan_tags_loaded(force: bool = False) -> List[str]:
+  +    if force or _clan_tags_need_refresh():
+  +        await _run_blocking(_load_clan_tags, force)
+  +    return list(_clan_tags_cache)
+  @@
+  -def _match_tag_in_text(text: str) -> Optional[str]:
+  -    if not text: return None
+  -    _load_clan_tags(False)
+  +def _match_tag_in_text(text: str) -> Optional[str]:
+  +    if not text: return None
+       if not _tag_regex_cache: return None
+       ...
+  @@
+  -    picked = _pick_tag_by_suffix(remainder, _load_clan_tags())
+  +    picked = _pick_tag_by_suffix(remainder, list(_clan_tags_cache))
+  @@
+  -    picked = _pick_tag_by_suffix(remainder, _load_clan_tags())
+  +    picked = _pick_tag_by_suffix(remainder, list(_clan_tags_cache))
+  @@
+  async def infer_clantag_from_thread(thread: discord.Thread) -> Optional[str]:
+  -    if not ENABLE_INFER_TAG_FROM_THREAD:
+  +    if not ENABLE_INFER_TAG_FROM_THREAD:
+           return None
+  +    await ensure_clan_tags_loaded(False)
+  @@
+  async def scan_welcome_channel(channel: discord.TextChannel, progress_cb=None):
+  -    st = backfill_state["welcome"] = _new_report_bucket()
+  +    st = backfill_state["welcome"] = _new_report_bucket()
+       if not ENABLE_WELCOME_SCAN:
+           backfill_state["last_msg"] = "welcome scan disabled"; return
+  +    await ensure_clan_tags_loaded(False)
+  @@
+  async def scan_promo_channel(channel: discord.TextChannel, progress_cb=None):
+  +    await ensure_clan_tags_loaded(False)
+  @@
+  async def on_message(message: discord.Message):
+       if isinstance(message.channel, discord.Thread):
+           th = message.channel
+  +        await ensure_clan_tags_loaded(False)
+  ```
+* **Verify:**
+  - Simulate Sheets outage (invalid credentials) and ensure `on_message` continues to process commands.
+  - Observe clan-tag prompts still populate options after TTL expiry.
+  - Run `!backfill_tickets` and confirm no blocking warnings in logs.
+
+### Medium & Low Severity
+_None beyond the above high-priority issues were found within the review scope._
+
+## Additional Notes
+- Keep the existing scheduled refresh loop; it benefits from the non-blocking loader and now short-circuits when tags are fresh.
+- Consider re-enabling Reminder’s structured logging once the carve-out progresses; audit trails ease live triage.

--- a/REVIEW/TESTPLAN.md
+++ b/REVIEW/TESTPLAN.md
@@ -1,0 +1,27 @@
+# Test Plan (Post-Fix)
+
+## Happy Paths
+1. **Welcome close with tag present**
+   - Create a welcome thread with canonical name + tag.
+   - Post “Ticket closed by …” message.
+   - Expect rename to `Closed-####-username-TAG`, Sheets row inserted, audit log entry.
+2. **Promo close with picker prompt**
+   - Close a promo thread without tag.
+   - Ensure prompt view appears once archived; pick a tag from dropdown.
+   - Confirm Sheets row added with detected promo type.
+3. **Dual-role ping in notify fallback**
+   - Close a private thread where the bot lacks send perms.
+   - Verify notify channel receives role + closer mentions.
+
+## Edge & Failure Cases
+1. **DM disabled / private thread fallback** — Ensure `_notify_channel` fires and pending state clears once tag provided.
+2. **Clan tag TTL expiry** — Advance clock or lower TTL, trigger close; ensure non-blocking refresh loads tags and watchers keep responding.
+3. **Sheets outage** — Inject invalid credentials, trigger close & prompt; verify Discord handlers remain responsive and notify fallback fires.
+4. **Duplicate ticket prevention** — Run backfill twice; ensure upsert updates existing rows instead of appending duplicates.
+5. **Rate limit resilience** — Simulate 429 from Sheets (mock `_with_backoff`) and confirm retries obey throttle.
+6. **Stale ticket sweep (future)** — Once implemented, simulate threads idle past SLA; expect reminder → auto-close flow.
+
+## Admin Surface
+1. **Permission checks** — Verify non-admins receive rejection for `!reboot`, `!backfill_tickets`, `!dedupe_sheet`, `!reload`, etc.
+2. **Env/Health commands** — As admin, call `!env_check`, `!health`, `!sheetstatus` and confirm output accuracy.
+3. **Slash `/help` parity** — Ensure slash and prefix help both reflect current command availability.

--- a/REVIEW/THREATS.md
+++ b/REVIEW/THREATS.md
@@ -1,0 +1,24 @@
+# Threat Model & Risks
+
+## Assets & Trust Boundaries
+- **Discord guilds** — Threads/channels where onboarding happens; bot must respect channel permissions.
+- **Google Sheets data** — Ticket logs, recruiter info, clan templates accessed via service account.
+- **Bot token & service account JSON** — Secrets provided through environment variables.
+- **Render deployment** — Hosts aiohttp health endpoints and long-lived Discord session.
+
+## Key Threats
+1. **Privilege escalation via prefix commands (F-01).** Attackers can reboot the bot, spam Sheets writes, or dump env hints by issuing admin commands from any channel.
+2. **Gateway starvation (F-02).** Blocking Sheets reads on the event loop causes missed Discord events, making the bot unreliable during outages.
+3. **Sheets abuse.** Without tighter scoping, repeated backfills or dedupe operations can thrash rate limits (mitigated by throttling but still manual-triggered).
+4. **Token leakage.** `!env_check` currently redacts poorly (first 6 chars only); ensure logs and command output avoid dumping secrets beyond operational need.
+
+## Mitigations
+- Add `Manage Server` (or recruiter role) checks before executing maintenance commands.
+- Offload Sheets access via `_run_blocking` and guard clan tag cache fetches with TTL checks.
+- Extend logging with correlation IDs so audit log (#audit-log) can trace actions without storing PII.
+- Store secrets in environment variables only; avoid writing service account JSON to disk during runtime.
+
+## Future Work
+- Implement a stale-ticket sweeper with idempotent retries and alerting instead of silent backlog.
+- Consider caching clan templates in memory with TTL + background refresh to reduce hot-path Sheets calls.
+- Add structured logging (JSON) for Render to make watchdog restarts observable.

--- a/REVIEW/TODOS.md
+++ b/REVIEW/TODOS.md
@@ -1,0 +1,11 @@
+# TODOs (≤60 min each)
+
+## P0
+- [F-01] Gate all admin/maintenance prefix commands behind a `Manage Server` (or equivalent recruiter/admin role) permission check, matching Reminder.
+- [F-02] Introduce a non-blocking clan-tag cache loader and ensure all hot paths preload via the thread pool helper before parsing.
+
+## P1
+- After F-02, add telemetry for cache refresh latency and failures to surface Sheets outages without blocking the gateway loop.
+
+## P2
+- Align docstrings/comments with the new permission model once F-01 lands (README command table currently implies admin-only).

--- a/REVIEW/TYPECHECK_REPORT.md
+++ b/REVIEW/TYPECHECK_REPORT.md
@@ -1,0 +1,3 @@
+# Type Check Report
+
+- `mypy`/`pyright`: Not run (not part of project tooling and unavailable in container). Manual review focused on runtime behavior of async/Sheets integration.


### PR DESCRIPTION
## Summary
- add the requested WelcomeCrew review deliverables, including the executive summary, findings, and supporting artifacts
- capture follow-up todos, architecture map, test plan, threat model, hotspot list, and tooling reports for the module carve-out

## Testing
- `python -m compileall bot_welcomecrew.py`


------
https://chatgpt.com/codex/tasks/task_e_68e373fef4208323b9068dc0759c3904