### PR TITLE
Adopt heartbeat watchdog config for WelcomeCrew

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Sample configuration for WelcomeCrew
+# Populate values and export/apply before running the bot.
+
+DISCORD_TOKEN=REPLACE_ME
+WELCOME_CHANNEL_ID=0
+PROMO_CHANNEL_ID=0
+GSHEET_ID=REPLACE_ME
+TIMEZONE=UTC
+
+# Watchdog / health tuning
+WATCHDOG_CHECK_SEC=60
+# Restart if connected but no events for this long (seconds) + bad latency
+WATCHDOG_ZOMBIE_SEC=600
+# Restart if disconnected from Discord for this long (seconds)
+WATCHDOG_DISCONNECT_AGE_SEC=600
+# Consider latency “bad” above this threshold (seconds)
+WATCHDOG_LATENCY_SEC=10
+# Legacy alias (WelcomeCrew only); prefer WATCHDOG_DISCONNECT_AGE_SEC
+# WATCHDOG_MAX_DISCONNECT_SEC=600
+
+# Health probe mode: 0 = soft ok on / and /ready, 1 = strict health everywhere
+STRICT_PROBE=0

--- a/README.md
+++ b/README.md
@@ -123,12 +123,12 @@ All commands are prefix (`!…`). A minimal slash command `/help` is also provid
 
 * Watchdog checks every `WATCHDOG_CHECK_SEC` (default 60s):
 
-  * If connected but no socket activity for >10m and latency is bad → restart.
-  * If disconnected > `WATCHDOG_MAX_DISCONNECT_SEC` (default 10m) → restart.
+  * If connected but no socket activity for >`WATCHDOG_ZOMBIE_SEC` (default 600s) **and** latency is bad (`WATCHDOG_LATENCY_SEC`, default 10s) → restart.
+  * If disconnected >`WATCHDOG_DISCONNECT_AGE_SEC` (default 600s; legacy alias `WATCHDOG_MAX_DISCONNECT_SEC`) → restart.
 * Web server:
 
   * `/` and `/ready` return **200** by default (or deep status when `STRICT_PROBE=1`).
-  * `/healthz` always returns deep status (200/206/503).
+  * `/healthz` always returns deep status (200/206/503). When connected but idle/slow you will see `206` and `connected: true`.
 
 ---
 

--- a/docs/DOCS_MAP.md
+++ b/docs/DOCS_MAP.md
@@ -1,15 +1,16 @@
 # Repository Documentation Map
 
-_Last updated: 2025-10-08_
+_Last updated: 2025-12-10_
 
 ## Global Docs
 - **Purpose**: Provide organization-wide engineering guardrails, development workflows, and supporting references.
 - **Location pattern**: `docs/*.md`
 - **Naming convention**: Uppercase snake-case filenames (e.g., `ENGINEERING.md`).
 - **Create when**: Introducing or revising global processes, onboarding guidance, or top-level handbooks.
-- **Current files (2)**:
+- **Current files (3)**:
   - `docs/DOCS_GLOSSARY.md` — Definitions for guardrails terminology.
   - `docs/DOCS_MAP.md` — This navigational index of documentation assets.
+  - `docs/ops/Config.md` — Watchdog and health configuration guide for WelcomeCrew.
 
 ## Architectural Decision Records (ADRs)
 - **Purpose**: Capture significant architectural and process decisions with rationale and status.

--- a/docs/ops/Config.md
+++ b/docs/ops/Config.md
@@ -1,0 +1,21 @@
+# WelcomeCrew Configuration Guide
+
+## Watchdog and Health Environment Variables
+
+Use these settings to tune watchdog and health behaviour (shared with Matchmaker/Clanmatch). Defaults shown in parentheses.
+
+- `WATCHDOG_CHECK_SEC` (60): Interval between watchdog checks.
+- `WATCHDOG_ZOMBIE_SEC` (600): If connected but no events have been seen for this many seconds **and** latency is bad, restart.
+- `WATCHDOG_DISCONNECT_AGE_SEC` (600): If disconnected from Discord for longer than this, restart.
+- `WATCHDOG_LATENCY_SEC` (10.0): Latency above this threshold counts as bad when combined with long idle time.
+- `WATCHDOG_MAX_DISCONNECT_SEC`: **Legacy alias** for `WATCHDOG_DISCONNECT_AGE_SEC` (WelcomeCrew only). Prefer the new name; the legacy value is still honoured when the new variable is absent.
+- `STRICT_PROBE` (0): Health probe mode. When `0`, `/` and `/ready` always return 200 while `/healthz` returns deep health (200/206/503). When `1`, `/`, `/ready`, `/health`, and `/healthz` all return deep health responses.
+
+## Notes
+
+- WelcomeCrew now uses the same heartbeat-driven watchdog thresholds as Matchmaker/Clanmatch. Adjust the thresholds above rather than relying on hard-coded 10-minute limits.
+- When connected but idle/slow, `/healthz` returns HTTP 206 with `connected: true` so observability remains intact without triggering premature restarts.
+
+---
+
+Doc last updated: 2025-12-10 (v0.9.8.x)


### PR DESCRIPTION
## Summary
- migrate WelcomeCrew watchdog and health handling to heartbeat-based tracking with env-driven thresholds and latency-aware zombie detection
- add graceful webserver shutdown handling and updated health payloads to surface disconnect age
- document unified watchdog variables and provide sample .env entries for configuration

## Testing
- python -m compileall bot_welcomecrew.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693a03e89428832d8a71c904b78249ba)